### PR TITLE
Autoloader

### DIFF
--- a/lib/urlresolver/__init__.py
+++ b/lib/urlresolver/__init__.py
@@ -27,7 +27,7 @@ For most cases you probably want to use :func:`urlresolver.resolve` or
 
 '''
 
-import os
+import os,xml.dom.minidom
 import common
 import plugnplay
 from types import HostedMediaFile
@@ -169,13 +169,14 @@ def display_settings():
     plugnplay.load_plugins()
     _update_settings_xml()
     common.addon.show_settings()
-        
-        
+
 def _update_settings_xml():
     '''
     This function writes a new ``resources/settings.xml`` file which contains
     all settings for this addon and its plugins.
     '''
+
+    pretty_print = lambda f: '\n'.join([line for line in f.split('\n') if line.strip()])
     
     lazy_plugin_scan()
     plugnplay.load_plugins()
@@ -187,20 +188,37 @@ def _update_settings_xml():
             pass
 
         f = open(common.settings_file, 'w')
+        xml_text = "<settings>"
+        for imp in PluginSettings.implementors():
+            xml_text += "<category label=\""+imp.name+"\">"
+            xml_text += imp.get_settings_xml()
+            xml_text += "</category>"
+        xml_text += "</settings>"
         try:
             f.write('<?xml version="1.0" encoding="utf-8" standalone="yes"?>\n')
-            f.write('<settings>\n')    
-            for imp in PluginSettings.implementors():
-                f.write('<category label="%s">\n' % imp.name)
-                f.write(imp.get_settings_xml())
-                f.write('</category>\n')
+            f.write("<settings>\n")
+            f.write("<category label=\"URLResolver\">\n")
+            f.write("\t<setting default=\"true\" ")
+            f.write("id=\"allow_universal\" ")
+            f.write("label=\"Enable Universal Resolvers\" type=\"bool\"/>\n")
+            f.write("\t<setting default=\"0.0.0\" ")
+            f.write("id=\"addon_version\" visible=\"false\" ")
+            f.write("label=\"URLResolver version\" type=\"text\"/>\n")
+            f.write("</category>\n")
+            settings_xml = xml.dom.minidom.parseString(xml_text)
+            elements = settings_xml.getElementsByTagName('category')
+            elements.sort(key=lambda x: x.getAttribute('label'))
+            for i in elements:
+                xml_text = i.toprettyxml()
+                f.write(pretty_print(xml_text))
             f.write('</settings>')
         finally:
             f.close
     except IOError:
         common.addon.log_error('error writing ' + common.settings_file)
 
-
-print "Almost there"
-#make sure settings.xml is up to date
-_update_settings_xml()
+#Update settings.xml if newer plugin version
+if common.addon.get_setting('addon_version') != common.addon.get_version():
+    common.addon.log_notice("Update settings from %s to %s " % (common.addon.get_setting('addon_version'), common.addon.get_version()))
+    _update_settings_xml()
+    common.addon.addon.setSetting('addon_version', common.addon.get_version())

--- a/lib/urlresolver/plugins/videovalley.py
+++ b/lib/urlresolver/plugins/videovalley.py
@@ -26,7 +26,7 @@ import re
 
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
-    name = "vidcrazy.net"
+    name = "videovalley.net"
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidpe.py
+++ b/lib/urlresolver/plugins/vidpe.py
@@ -26,6 +26,7 @@ from lib import jsunpack
 
 class vidpeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
+    name = "vidpe"
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugnplay/__init__.py
+++ b/lib/urlresolver/plugnplay/__init__.py
@@ -19,9 +19,10 @@
 
 from glob import glob
 from os.path import join, basename
-import sys
+import sys, re
 from urlresolver import common
 from manager import *
+from types import FunctionType, ClassType
 
 __version__ = "0.1"
 
@@ -32,48 +33,175 @@ man = Manager()
 
 plugin_dirs = []
 
+def _is_method(o):
+    return type(o) is FunctionType
+
+
+''' Template that defines the parent properties into AutoloadPlugin properties
+'''
+def attr_set_property(attr_name):
+    def _get_x(impl):
+        try:
+            return getattr(impl._ref, attr_name)
+        except:
+            pass
+    def _set_x(impl, value):
+        try:
+            setattr(impl._ref, attr_name, value)
+        except:
+            pass
+    return property(_get_x, _set_x)
+
+
+''' Template that wraps an existing function in the parent class into a
+    function with the same name in the AutoloadPlugin.
+'''
+def method_name_and_load(method_name):
+    def _auto_caller_template(impl, *args, **kwargs):
+        try:
+            method = getattr(impl._ref, method_name)
+            return method(*args, **kwargs)
+        except ImportError:
+            load_plugin(impl)
+            method = getattr(impl, method_name)
+            return method(*args, **kwargs)
+
+    return _auto_caller_template
+
+
+def canonical_name(obj):
+    return "{0}.{1}".format(obj.__module__, obj.__name__)
+
+
+'''
+Wrapper for public interfaces
+'''
+class AutoloadMeta(type):
+    def __new__(metaclass, classname, bases, attrs):
+        new_class = super(AutoloadMeta, metaclass).__new__(metaclass, classname, bases, attrs)
+        for b in bases:
+            # print classname, b, type(b)
+            # Ignore non classes
+            if type(b) != ClassType:
+                continue
+            # Check parent dictionary
+            for k in b.__dict__:
+                v = b.__dict__[k]
+                # print (k, type(v))
+                if k in new_class.__dict__:
+                    continue
+                # print (k, type(v))
+                if type(v) == FunctionType:
+                    # print k
+                    setattr(new_class, k, method_name_and_load(k))
+                else:
+                    setattr(new_class, k, attr_set_property(k))
+        return new_class
+
+    def __eq__(self, other):
+        return canonical_name(self) == canonical_name(other)
+
+    def __ne__(self, other):
+        return not self.__eq__(other)
+
+    def __hash__(self):
+        return hash(canonical_name(self))
+
 '''
   Marker for public interfaces
 '''
-class Interface(object):
-  
-  @classmethod
-  def implementors(klass):
-    return man.implementors(klass)
+class Interface():
+    @classmethod
+    def implementors(klass):
+        return man.implementors(klass)
 
 
+'''
+  Plugin's metaclass
+  Create a Plugin class, and add a implementor from the newly created class
+'''
 class PluginMeta(type):
-  
-  def __new__(metaclass, classname, bases, attrs):
-    new_class = super(PluginMeta, metaclass).__new__(metaclass, classname,
-        bases, attrs)
-    
-    new_class_instance = new_class()
-    if attrs.has_key('implements'):
-      for interface in attrs['implements']:
-        man.add_implementor(interface, new_class_instance)
-        common.addon.log_debug('registering plugin: %s (%s), as: %s (P=%d)' % \
-                       (new_class.name, new_class.__name__, interface.__name__, 
-                        new_class_instance.priority))
 
-    return new_class
+    def __new__(metaclass, classname, bases, attrs):
+        new_class = super(PluginMeta, metaclass).__new__(metaclass, classname,
+                                                         bases, attrs)
 
-class Plugin(object):
-  __metaclass__ = PluginMeta
+        new_class_instance = new_class()
+        if attrs.has_key('implements'):
+            for interface in attrs['implements']:
+                notfound = True
+                for impl in man.implementors(interface):
+                    if impl.name == new_class_instance.name:
+                        if getattr(impl, '_ref'):
+                            impl._ref = new_class_instance
+                            return # Wrapper will take care of all instances
+                        else:
+                            # Normal implementor
+                            impl = new_class_instance
+                            notfound = False
+                if notfound: man.add_implementor(interface, new_class_instance)
+
+        return new_class
+
+# class Plugin(object):
+#     __metaclass__ = PluginMeta
+Plugin = PluginMeta('Plugin', (object, ), {})
+
+#class AutoloadPlugin(object):
+#    __metaclass__ = AutoloadMeta
+AutoloadPlugin = AutoloadMeta('AutoloadPlugin', (object, ), {})
+
+# Interface = InterfaceMeta('Interface', (object, ), {'implementors': implementors})
 
 
+''' More functions '''
 def set_plugin_dirs(*dirs):
   for d in dirs:
     common.addon.log_debug('adding plugin dir: %s' % d)
-    plugin_dirs.append(d)
-  
+    plugin_dirs.append(d)  
+
+def load_plugin(mod):
+    common.addon.log_debug('loading plugin: %s from %s' % (mod.name, mod.fname))
+    imported_module = __import__(mod.fname, globals(), locals())
+    sys.modules[mod.fname] = imported_module
+
 def load_plugins():
-  for d in plugin_dirs:
-    sys.path.append(d)
-    py_files = glob(join(d, '*.py'))
-    
-    #Remove ".py" for proper importing
-    modules = [basename(f[:-3]) for f in py_files]
-    for mod_name in modules:
-      imported_module = __import__(mod_name, globals(), locals())
-      sys.modules[mod_name] = imported_module
+    for d in plugin_dirs:
+        sys.path.append(d)
+        py_files = glob(join(d, '*.py'))
+
+        # Remove ".py" for proper importing
+        modules = [basename(f[:-3]) for f in py_files]
+        for mod_name in modules:
+            imported_module = __import__(mod_name, globals(), locals())
+            sys.modules[mod_name] = imported_module
+
+def scan_plugins(wrappercls):
+    re_class = re.compile('class\s+(\w+).*Plugin')
+    for d in plugin_dirs:
+        sys.path.append(d)
+        py_files = glob(join(d, '*.py'))
+        for f in py_files:
+            found_plugin = None
+            mod_name = basename(f[:-3])
+            for line in open(f, 'r'):
+                if None == found_plugin:
+                    res = re_class.match(line)
+                    if res:
+                        found_plugin = wrappercls()
+                        found_plugin.fname = mod_name
+                        found_plugin.class_name = res.group(1)
+                else:
+                    found_plugin.proc_plugin_line(line)
+                    if found_plugin.plugin_ready():
+                        _enabled = common.addon.get_setting('%s_enabled' % found_plugin.class_name)
+                        if _enabled == "false": break
+                        _priority = common.addon.get_setting('%s_priority' % found_plugin.class_name)
+                        try:
+                            found_plugin.priority = int(_priority)
+                        except ValueError:
+                            found_plugin.priority = 100
+                        for cls in found_plugin.implements:
+                            common.addon.log_debug("module %s supports %s" % (mod_name, cls))
+                            man.add_implementor(cls, found_plugin)
+                        break # Next file

--- a/lib/urlresolver/plugnplay/interfaces.py
+++ b/lib/urlresolver/plugnplay/interfaces.py
@@ -36,8 +36,9 @@ should be defined as follows::
 
 import urlresolver
 from urlresolver import common
-from urlresolver.plugnplay import Interface
-import sys
+from urlresolver.plugnplay import Interface, AutoloadPlugin
+import sys, re
+from fnmatch import translate
 
 def _function_id(obj, nFramesUp):
 	'''Create a string naming the function n frames up on the stack.'''
@@ -47,8 +48,11 @@ def _function_id(obj, nFramesUp):
 
 
 def not_implemented(obj=None):
-	'''Use this instead of ``pass`` for the body of abstract methods.'''
-	raise Exception("Unimplemented abstract method: %s" % _function_id(obj, 1))
+    '''Use this instead of ``pass`` for the body of abstract methods.
+       Use ImportError to indicate that the module hasn't yet been
+       loaded into memory.
+    '''
+    raise ImportError("Unimplemented abstract method: %s" % _function_id(obj, 1))
 
 
 class UrlResolver(Interface):
@@ -66,14 +70,19 @@ class UrlResolver(Interface):
     '''
     
     name = 'override_me'
-    '''(str) A human readable name for your plugin.'''
+    '''(str) A human readable name for your plugin. Must be defined and be unique'''
 
     priority = 100
     '''
     (int) The order in which plugins will be tried. Lower numbers are tried 
     first.
-    '''    
-
+    '''
+    
+    # Don't support any internet domain
+    domains = ['localdomain']
+    
+    '''(array) List of domains handled by this plugin. Use ["*"] for universal resolvers.'''
+    
     class unresolvable():
         '''
         An object returned to indicate that the url could not be resolved
@@ -99,6 +108,7 @@ class UrlResolver(Interface):
         def __init__(self, code=0, msg='Unknown Error'):
             self.code = code
             self.msg = msg
+            self._labels = {}
 
         def __nonzero__(self):
             return 0
@@ -137,9 +147,9 @@ class UrlResolver(Interface):
 
     def get_host_and_id(self, url):
         not_implemented(self)
-
-
-    def valid_url(self, web_url):
+    
+    
+    def valid_url(self, web_url, host):
         '''
         Determine whether this plugin is capable of resolving this URL. You must 
         implement this method.
@@ -335,3 +345,48 @@ class PluginSettings(Interface):
         value = common.addon.get_setting('%s_%s' % 
                                                 (self.__class__.__name__, key))
         return value
+
+''' Dummy class for uninitialized plugins
+    All bounded methods should be declared as "non_implemented" 
+'''
+class UrlStub(UrlResolver, PluginSettings, SiteAuth):
+    pass
+
+class UrlWrapper(UrlResolver, PluginSettings, SiteAuth, AutoloadPlugin):
+    _ref = UrlStub()
+    implements = []
+    _re_implements = re.compile('\s+implements\s*=\s*\[(.*)\]')
+    _re_name = re.compile('\s+name\s*=\s*[\'"](.*)[\'"]')
+    _found_implements = False
+    _found_name = False
+
+    def __init__(self):
+        self.implements=[]
+        self._ref = UrlStub()
+
+    def proc_plugin_line(self, line):
+        ''' Simple parser for Python source code.
+            Find the lines that define which domains are supported,
+            and which interface is implemented.
+        '''
+        if not self._found_implements:
+            res = self._re_implements.match(line)
+            if res:
+                implements_names = res.group(1).translate(None,' "\'').split(',')
+                for handler in implements_names:
+                    self.implements.append(globals()[handler])
+                self._found_implements = True
+        
+        if not self._found_name:
+            res = self._re_name.match(line)
+            if res:
+                self.name = res.group(1)
+                self._found_name = True
+    
+    def plugin_ready(self):
+        return (self._found_implements and self._found_name)
+    
+    @classmethod
+    def implementors(klass):
+        return UrlResolver.implementors()
+

--- a/lib/urlresolver/plugnplay/manager.py
+++ b/lib/urlresolver/plugnplay/manager.py
@@ -23,18 +23,21 @@
 '''
 class Manager(object):
 
-  def __init__(self):
-    self.iface_implementors = {}
+    def __init__(self):
+        self.iface_implementors = {}
 
-
-  def add_implementor(self, interface, implementor_instance):
-    self.iface_implementors.setdefault(interface, [])
-    for index, item in enumerate(self.iface_implementors[interface]):
-        if implementor_instance.priority <= item.priority:
-            self.iface_implementors[interface].insert(index, 
+    def add_implementor(self, interface, implementor_instance):
+        self.iface_implementors.setdefault(interface, [])
+        for index, item in enumerate(self.iface_implementors[interface]):
+            if implementor_instance.priority <= item.priority:
+                self.iface_implementors[interface].insert(index,
                                                       implementor_instance)
-            return
-    self.iface_implementors[interface].append(implementor_instance)
+                return
+        self.iface_implementors[interface].append(implementor_instance)
 
-  def implementors(self, interface):
-    return self.iface_implementors.get(interface, [])
+    def is_empty(self):
+        return {} == self.iface_implementors
+
+    def implementors(self, interface):
+        self.iface_implementors.setdefault(interface, [])
+        return self.iface_implementors.get(interface, [])

--- a/lib/urlresolver/types.py
+++ b/lib/urlresolver/types.py
@@ -198,6 +198,7 @@ class HostedMediaFile:
         return int(http_code) < 400
     
     def _find_resolvers(self):
+        urlresolver.lazy_plugin_scan()
         imps = []
         for imp in UrlResolver.implementors():
             if imp.valid_url(self.get_url(), self.get_host()):


### PR DESCRIPTION
Changes to reduce initialization time.

First change is not loading all resolvers into memory at init time, but only when they are used. To do this, metaclass AutoloaderMeta catches class initialization, and create wrappers for inherited functions that point  to an internal object self._ref. For example, class UrlWrapper, that inherits from UrlResolver, PluginSettings, SiteAuth & AutoloadPlugin, will have a method called get_media_url() inherited from UrlResolver, that would actually call self._ref.get_media_url(). By default, such methods just call "not_implemented()", which triggers an exception catched by the wrapper and used to load the actual resolver. The only requirement is that resolvers MUST have a name, but otherwise they are unchanged and unaware of any change in plugnplay library. Note that this change by itself doesn't change total resolution time, as all resolvers are still loaded to memory when instantiating HostMediaFile().

The second patch is simpler, as it only checks if there has been a software update before writing a new settings.xml file. It also adds some pretty printing to the file, and sorts the resolvers by name to make them easier to find in the settings screen.
