### PR TITLE
Domaincheck

### DIFF
--- a/lib/urlresolver/plugins/180upload.py
+++ b/lib/urlresolver/plugins/180upload.py
@@ -33,6 +33,9 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class OneeightyuploadResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "180upload"
+    domains = [ "180upload.com" ]
+    
+
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/alldebrid.py
+++ b/lib/urlresolver/plugins/alldebrid.py
@@ -37,6 +37,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class AllDebridResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, SiteAuth, PluginSettings]
     name = "AllDebrid"
+    domains = [ '*']
     profile_path = common.profile_path    
     cookie_file = os.path.join(profile_path, '%s.cookies' % name)
     media_url = None

--- a/lib/urlresolver/plugins/allmyvideos.py
+++ b/lib/urlresolver/plugins/allmyvideos.py
@@ -29,6 +29,9 @@ USER_AGENT='Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:30.0) Gecko/20100101 Firefo
 class AllmyvideosResolver(Plugin,UrlResolver,PluginSettings):
     implements=[UrlResolver,PluginSettings]
     name="allmyvideos"
+    domains=[ "allmyvideos.net" ]
+
+
     def __init__(self):
         p=self.get_setting('priority') or 100
         self.priority=int(p)

--- a/lib/urlresolver/plugins/auengine.py
+++ b/lib/urlresolver/plugins/auengine.py
@@ -27,25 +27,26 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "auengine.com"
-    
+    domains = [ "auengine.com" ]
+
     def __init__(self):
         p = self.get_setting('priority') or 100
         self.priority = int(p)
         self.net = Net()
         self.pattern = 'http://((?:www.)?auengine.com)/embed.php\?file=([0-9a-zA-Z\-_]+)[&]*'
-    
+
     def get_url(self, host, media_id):
             return 'http://www.auengine.com/embed.php?file=%s' % (media_id) #&w=800&h=600
-    
+
     def get_host_and_id(self, url):
         r = re.search(self.pattern, url)
         if r: return r.groups()
         else: return False
-    
+
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False
         return re.match(self.pattern, url) or self.name in host
-    
+
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
         post_url = web_url
@@ -65,4 +66,4 @@ class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
             common.addon.log_error(hostname+': stream url not found')
             return self.unresolvable(code=0, msg='no file located') #return False
         return stream_url
-	
+

--- a/lib/urlresolver/plugins/bayfiles.py
+++ b/lib/urlresolver/plugins/bayfiles.py
@@ -27,6 +27,7 @@ from time import time as wait
 class bayfilesResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "bayfiles"
+    domains = [ "bayfiles.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/bestreams.py
+++ b/lib/urlresolver/plugins/bestreams.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class BestreamsResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "bestreams"
+    domains = [ "bestreams.net" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/billionuploads.py
+++ b/lib/urlresolver/plugins/billionuploads.py
@@ -32,6 +32,7 @@ MAX_TRIES = 3
 class billionuploads(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "billionuploads"
+    domains = [ "billionuploads.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/castamp.py
+++ b/lib/urlresolver/plugins/castamp.py
@@ -35,6 +35,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class CastampResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "castamp"
+    domains = [ "castamp.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/cloudy.py
+++ b/lib/urlresolver/plugins/cloudy.py
@@ -33,6 +33,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class CloudyResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "cloudy.ec"
+    domains = [ "cloudy.ec", "cloudy.eu", "cloudy.sx", "cloudy.ch", "cloudy.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/cloudyvideos.py
+++ b/lib/urlresolver/plugins/cloudyvideos.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class CloudyvideosResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "cloudyvideos"
+    domains = [ "cloudyvideos.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/crunchyroll.py
+++ b/lib/urlresolver/plugins/crunchyroll.py
@@ -28,6 +28,7 @@ import os
 class crunchyrollResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "crunchyroll"
+    domains = [ "crunchyroll.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/cyberlocker.py
+++ b/lib/urlresolver/plugins/cyberlocker.py
@@ -33,6 +33,7 @@ net = Net()
 class CyberlockerResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "cyberlocker"
+    domains = [ "cyberlocker.ch" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/daclips.py
+++ b/lib/urlresolver/plugins/daclips.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class DaclipsResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "daclips"
+    domains = [ "daclips.in", "daclips.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/dailymotion.py
+++ b/lib/urlresolver/plugins/dailymotion.py
@@ -30,6 +30,7 @@ logo=os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class DailymotionResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "dailymotion"
+    domains = [ "dailymotion.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/divxstage.py
+++ b/lib/urlresolver/plugins/divxstage.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class DivxstageResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "divxstage"
+    domains = [ "divxstage.eu", "divxstage.net", "divxstage.to" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100
@@ -82,4 +83,4 @@ class DivxstageResolver(Plugin, UrlResolver, PluginSettings):
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False
         #http://embed.divxstage.eu/embed.php?v=8da26363e05fd&width=746&height=388&c=000
-        return (re.match('http://(?:www.|embed.)?divxstage.(?:eu|net)/', url) or 'divxstage' in host)
+        return (re.match('http://(?:www.|embed.)?divxstage.(?:eu|net|to)/', url) or 'divxstage' in host)

--- a/lib/urlresolver/plugins/donevideo.py
+++ b/lib/urlresolver/plugins/donevideo.py
@@ -29,6 +29,7 @@ net = Net()
 class DonevideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "donevideo"
+    domains = [ "donevideo.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/ecostream.py
+++ b/lib/urlresolver/plugins/ecostream.py
@@ -32,6 +32,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class EcostreamResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "ecostream"
+    domains = [ "ecostream.tv" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, 'ecostream.cookies')
 

--- a/lib/urlresolver/plugins/facebook.py
+++ b/lib/urlresolver/plugins/facebook.py
@@ -31,6 +31,7 @@ logo=os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class FacebookResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "facebook"
+    domains = [ "facebook.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/filenuke.py
+++ b/lib/urlresolver/plugins/filenuke.py
@@ -31,6 +31,7 @@ USER_AGENT='Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:30.0) Gecko/20100101 Firefo
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "filenuke"
+    domains = [ "filenuke.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/flashx.py
+++ b/lib/urlresolver/plugins/flashx.py
@@ -33,6 +33,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class FlashxResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "flashx"
+    domains = [ "flashx.tv" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/gorillavid.py
+++ b/lib/urlresolver/plugins/gorillavid.py
@@ -29,6 +29,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class GorillavidResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "gorillavid"
+    domains = [ "gorillavid.in", "gorillavid.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/hostingbulk.py
+++ b/lib/urlresolver/plugins/hostingbulk.py
@@ -32,6 +32,7 @@ logo=os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class hostingbulkResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "hostingbulk"
+    domains = [ "hostingbulk.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/hugefiles.py
+++ b/lib/urlresolver/plugins/hugefiles.py
@@ -29,6 +29,7 @@ net = Net()
 class HugefilesResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "hugefiles"
+    domains = [ "hugefiles.net" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/jumbofiles.py
+++ b/lib/urlresolver/plugins/jumbofiles.py
@@ -27,6 +27,7 @@ from urlresolver import common
 class JumbofilesResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "jumbofiles"
+    domains = [ "jumbofiles.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/letwatch.py
+++ b/lib/urlresolver/plugins/letwatch.py
@@ -28,6 +28,7 @@ logo=os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class LetwatchResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "letwatch.us"
+    domains = [ "letwatch.us" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/limevideo.py
+++ b/lib/urlresolver/plugins/limevideo.py
@@ -29,6 +29,7 @@ net = Net()
 class LimevideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "limevideo"
+    domains = [ "limevideo.net" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/megavids.py
+++ b/lib/urlresolver/plugins/megavids.py
@@ -32,6 +32,7 @@ net = Net()
 class AllmyvideosResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "mega-vids"
+    domains = [ "mega-vids.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/mightyupload.py
+++ b/lib/urlresolver/plugins/mightyupload.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class MightyuploadResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "mightyupload"
+    domains = [ "mightyupload.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/mooshare_biz.py
+++ b/lib/urlresolver/plugins/mooshare_biz.py
@@ -32,6 +32,7 @@ net = Net()
 class AllmyvideosResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "mooshare"
+    domains = [ "mooshare.biz" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/movdivx.py
+++ b/lib/urlresolver/plugins/movdivx.py
@@ -33,6 +33,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class MovDivxResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "movdivx"
+    domains = [ "movdivx.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/movpod.py
+++ b/lib/urlresolver/plugins/movpod.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class MovpodResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "movpod"
+    domains = [ "movpod.net", "movpod.in" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/movreel.py
+++ b/lib/urlresolver/plugins/movreel.py
@@ -32,6 +32,7 @@ net = Net()
 class movreelResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, SiteAuth, PluginSettings]
     name = "movreel"
+    domains = [ "movreel.com" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, '%s.cookies' % name)
 

--- a/lib/urlresolver/plugins/movshare.py
+++ b/lib/urlresolver/plugins/movshare.py
@@ -37,6 +37,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class MovshareResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "movshare"
+    domains = [ "movshare.net" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/movzap.py
+++ b/lib/urlresolver/plugins/movzap.py
@@ -37,6 +37,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class MovzapZuzVideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "movzap|zuzvideo"
+    domains = [ "movzap.com", "zuzvideo.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/mp4star.py
+++ b/lib/urlresolver/plugins/mp4star.py
@@ -26,6 +26,7 @@ import urllib,urllib2,re,xbmc
 class MP4StarResolver(Plugin,UrlResolver,PluginSettings):
     implements=[UrlResolver,PluginSettings]
     name="mp4star"
+    domains=[ "mp4star.com" ]
     domain="http://mp4star.com"
     
     def __init__(self):

--- a/lib/urlresolver/plugins/mp4stream.py
+++ b/lib/urlresolver/plugins/mp4stream.py
@@ -29,6 +29,7 @@ import xbmcgui
 class Mp4streamResolver(Plugin, UrlResolver, PluginSettings):
 	implements = [UrlResolver, PluginSettings]
 	name = "mp4stream"
+	domains = [ "mp4stream.com" ]
 
 	def __init__(self):
 		p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/mp4upload.py
+++ b/lib/urlresolver/plugins/mp4upload.py
@@ -29,6 +29,7 @@ import xbmcgui
 class Mp4uploadResolver(Plugin, UrlResolver, PluginSettings):
 	implements = [UrlResolver, PluginSettings]
 	name = "mp4upload"
+	domains = [ "mp4upload.com" ]
 
 	def __init__(self):
 		p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/mrfile.py
+++ b/lib/urlresolver/plugins/mrfile.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class mrfileResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "mrfile"
+    domains = [ "mrfile.me" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/muchshare.py
+++ b/lib/urlresolver/plugins/muchshare.py
@@ -28,6 +28,7 @@ net = Net()
 class MuchshareResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "muchshare"
+    domains = [ "muchshare.net" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/nosvideo.py
+++ b/lib/urlresolver/plugins/nosvideo.py
@@ -32,6 +32,7 @@ net = Net()
 class NosvideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "nosvideo"
+    domains = [ "nosvideo.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/novamov.py
+++ b/lib/urlresolver/plugins/novamov.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class NovamovResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "novamov"
+    domains = [ "novamov.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/nowvideo.py
+++ b/lib/urlresolver/plugins/nowvideo.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class NowvideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "nowvideo"
+    domains = [ "nowvideo.eu","nowvideo.ch","nowvideo.sx" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/play44_net.py
+++ b/lib/urlresolver/plugins/play44_net.py
@@ -27,6 +27,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "play44.net"
+    domains = [ "play44.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/played.py
+++ b/lib/urlresolver/plugins/played.py
@@ -23,6 +23,8 @@ error_logo=os.path.join(common.addon_path,'resources','images','redx.png')
 class playedResolver(Plugin,UrlResolver,PluginSettings):
     implements=[UrlResolver,PluginSettings]
     name="played"
+    domains=[ "played.to" ]
+
     def __init__(self):
         p=self.get_setting('priority') or 100
         self.priority=int(p)

--- a/lib/urlresolver/plugins/playwire.py
+++ b/lib/urlresolver/plugins/playwire.py
@@ -32,6 +32,7 @@ logo=os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class PlaywireResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "playwire"
+    domains = [ "playwire.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/premiumize_me.py
+++ b/lib/urlresolver/plugins/premiumize_me.py
@@ -33,6 +33,7 @@ except ImportError:
 class PremiumizeMeResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "Premiumize.me"
+    domains = [ "*" ]
     media_url = None
 
     def __init__(self):

--- a/lib/urlresolver/plugins/primeshare.py
+++ b/lib/urlresolver/plugins/primeshare.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class PrimeshareResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "primeshare"
+    domains = [ "primeshare.tv" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, 'primeshare.cookies')
 

--- a/lib/urlresolver/plugins/promptfile.py
+++ b/lib/urlresolver/plugins/promptfile.py
@@ -29,6 +29,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class PromptfileResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "promptfile"
+    domains = [ "promptfile.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/purevid.py
+++ b/lib/urlresolver/plugins/purevid.py
@@ -38,6 +38,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class purevid(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements   = [UrlResolver, SiteAuth, PluginSettings]
     name         = "purevid"
+    domains = [ "purevid.com" ]
     profile_path = common.profile_path    
     cookie_file  = os.path.join(profile_path, '%s.cookies' % name)
     

--- a/lib/urlresolver/plugins/putlocker.py
+++ b/lib/urlresolver/plugins/putlocker.py
@@ -35,7 +35,8 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 
 class PutlockerResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
-    name = "putlocker/filedrive/firedrive"
+    name = "putlocker"
+    domains = [ "putlocker.com", "filedrive.com", "firedrive.com" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, 'putlocker.cookies')
 

--- a/lib/urlresolver/plugins/rapidvideo.py
+++ b/lib/urlresolver/plugins/rapidvideo.py
@@ -30,6 +30,7 @@ import re
 class RapidvideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "rapidvideo"
+    domains = [ "rapidvideo.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/realdebrid.py
+++ b/lib/urlresolver/plugins/realdebrid.py
@@ -35,6 +35,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class RealDebridResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, SiteAuth, PluginSettings]
     name = "realdebrid"
+    domains = [ "*" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, '%s.cookies' % name)
     media_url = None

--- a/lib/urlresolver/plugins/realvid.py
+++ b/lib/urlresolver/plugins/realvid.py
@@ -30,6 +30,7 @@ logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class RealvidResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "Realvid"
+    domains = ["realvid.net"]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/rpnet.py
+++ b/lib/urlresolver/plugins/rpnet.py
@@ -34,6 +34,7 @@ except ImportError:
 class RPnetResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "RPnet"
+    domains = [ "*" ]
     media_url = None
     allHosters = None
 

--- a/lib/urlresolver/plugins/sharedsx.py
+++ b/lib/urlresolver/plugins/sharedsx.py
@@ -32,6 +32,7 @@ net = Net()
 class SharedsxResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "sharedsx"
+    domains = [ "shared.sx" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/sharerepo.py
+++ b/lib/urlresolver/plugins/sharerepo.py
@@ -34,6 +34,7 @@ net = Net()
 class SharerepoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "sharerepo"
+    domains = [ "sharerepo.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/sharesix.py
+++ b/lib/urlresolver/plugins/sharesix.py
@@ -31,6 +31,7 @@ USER_AGENT='Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:30.0) Gecko/20100101 Firefo
 class SharesixResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "sharesix"
+    domains = [ "sharesix.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/sharevid.py
+++ b/lib/urlresolver/plugins/sharevid.py
@@ -32,6 +32,7 @@ net = Net()
 class AllmyvideosResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "sharevid"
+    domains = [ "sharevid.org" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/sockshare.py
+++ b/lib/urlresolver/plugins/sockshare.py
@@ -36,6 +36,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class sockshareResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "sockshare"
+    domains = [ "sockshare.com" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, 'sockshare.cookies')
 

--- a/lib/urlresolver/plugins/speedvideo.py
+++ b/lib/urlresolver/plugins/speedvideo.py
@@ -32,6 +32,7 @@ ok_logo=os.path.join(common.addon_path,'resources','images','greeninch.png')
 class SpeedVideoResolver(Plugin,UrlResolver,PluginSettings):
     implements=[UrlResolver,PluginSettings]
     name="speedvideo"
+    domains = [ "speedvideo.net" ]
     domain="speedvideo.net"
     USER_AGENT='Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:30.0) Gecko/20100101 Firefox/30.0'
     

--- a/lib/urlresolver/plugins/stagevu.py
+++ b/lib/urlresolver/plugins/stagevu.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class StagevuResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "stagevu"
+    domains = [ "stagevu.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/streaminto.py
+++ b/lib/urlresolver/plugins/streaminto.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class streamintoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "streaminto"
+    domains = ["streamin.to"]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/thefile.py
+++ b/lib/urlresolver/plugins/thefile.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class TheFileResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "thefile"
+    domains = [ "thefile.me" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/thevideo.py
+++ b/lib/urlresolver/plugins/thevideo.py
@@ -30,6 +30,7 @@ MAX_TRIES=3
 class TheVideoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "thevideo"
+    domains = [ "thevideo.me" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/trollvid.py
+++ b/lib/urlresolver/plugins/trollvid.py
@@ -27,6 +27,7 @@ import re,xbmc
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "trollvid.net"
+    domains = [ "trollvid.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/tubeplus.py
+++ b/lib/urlresolver/plugins/tubeplus.py
@@ -28,6 +28,7 @@ from urlresolver.plugnplay import Plugin
 class TubeplusResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver]
     name = "tubeplus.me"
+    domains = [ "tubeplus.me" ]
     
     def __init__(self):
         self.net = Net()

--- a/lib/urlresolver/plugins/tunepk.py
+++ b/lib/urlresolver/plugins/tunepk.py
@@ -31,6 +31,7 @@ logo=os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class TunePkResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "tune.pk"
+    domains = [ "tune.pk" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/uploadc.py
+++ b/lib/urlresolver/plugins/uploadc.py
@@ -29,6 +29,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class UploadcResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "uploadc"
+    domains = [ "uploadc.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/uploadcrazynet.py
+++ b/lib/urlresolver/plugins/uploadcrazynet.py
@@ -27,6 +27,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "uploadcrazy.net"
+    domains = [ "uploadcrazy.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100
@@ -70,4 +71,4 @@ class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
             common.addon.log_error(hostname+': stream url not found')
             return self.unresolvable(code=0, msg='no file located') #return False
         return stream_url
-	
+

--- a/lib/urlresolver/plugins/veeHD.py
+++ b/lib/urlresolver/plugins/veeHD.py
@@ -29,6 +29,7 @@ net = Net()
 class veeHDResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, SiteAuth, PluginSettings]
     name = "veeHD"
+    domains = [ "veehd.com" ]
     profile_path = common.profile_path
     cookie_file = os.path.join(profile_path, '%s.cookies' % name)
     

--- a/lib/urlresolver/plugins/veoh.py
+++ b/lib/urlresolver/plugins/veoh.py
@@ -27,6 +27,7 @@ from urlresolver.plugnplay import Plugin
 class VeohResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "veoh"
+    domains = [ "veoh.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidbull.py
+++ b/lib/urlresolver/plugins/vidbull.py
@@ -30,6 +30,7 @@ USER_AGENT = 'Mozilla/5.0 (Linux; Android 4.4; Nexus 5 Build/BuildID) AppleWebKi
 class VidbullResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidbull"
+    domains = [ "vidbull.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidcrazynet.py
+++ b/lib/urlresolver/plugins/vidcrazynet.py
@@ -27,6 +27,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidcrazy.net"
+    domains = [ "vidcrazy.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100
@@ -66,4 +67,4 @@ class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
             common.addon.log_error(hostname+': stream url not found')
             return self.unresolvable(code=0, msg='no file located') #return False
         return stream_url
-	
+

--- a/lib/urlresolver/plugins/video44.py
+++ b/lib/urlresolver/plugins/video44.py
@@ -30,6 +30,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "video44.net"
+    domains = [ "video44.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videobb.py
+++ b/lib/urlresolver/plugins/videobb.py
@@ -18,6 +18,7 @@ except ImportError:
 class VideobbResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videobb"
+    domains = [ "videobb.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videoboxone.py
+++ b/lib/urlresolver/plugins/videoboxone.py
@@ -27,6 +27,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videoboxone.com"
+    domains = [ "videoboxone.com" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videofun.py
+++ b/lib/urlresolver/plugins/videofun.py
@@ -30,6 +30,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videofun.me"
+    domains = [ "videofun.me" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videohut.py
+++ b/lib/urlresolver/plugins/videohut.py
@@ -33,6 +33,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VideoHutResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videohut.to"
+    domains = [ "videohut.to" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videomega.py
+++ b/lib/urlresolver/plugins/videomega.py
@@ -29,6 +29,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VideomegaResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videomega"
+    domains = [ "videomega.tv", "movieshd.co" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100
@@ -50,12 +51,12 @@ class VideomegaResolver(Plugin, UrlResolver, PluginSettings):
                 if r:
                     stream_url = r.group(1)
                     stream_url = stream_url.replace(" ","%20")
-                
+
             if stream_url:
                 return stream_url
             else:
                 return self.unresolvable(0, 'No playable video found.')
-            
+
         except urllib2.URLError, e:
             common.addon.log_error('Videomega: got http error %d fetching %s' %
                                     (e.code, web_url))
@@ -69,11 +70,31 @@ class VideomegaResolver(Plugin, UrlResolver, PluginSettings):
         return 'http://%s/iframe.php?ref=%s' % (host,media_id)
 
     def get_host_and_id(self, url):
-        r = re.search('//((?:www.)?(?:.+?))/(?:iframe.(?:php|js)\?ref=)([0-9a-zA-Z]+)', url)
-        if r:
+        r = re.search('//((?:www.)?(?:videomega.+?))/(?:iframe.(?:php|js)\?ref=)([0-9a-zA-Z]+)', url)
+        q = re.search('//(?:www.)?movieshd.co/watch-online/.*html', url)
+        if r: # videomega link
             return r.groups()
-        else:
-            return False
+        elif q: # movieshd link
+            try:
+                # Request MoviesHD page
+                req = urllib2.Request(url)
+                req.add_header('User-Agent', 'Mozilla/5.0 (Windows; U; Windows NT 5.1; en-GB; rv:1.9.0.3) Gecko/2008092417 Firefox/3.0.3')
+                response = urllib2.urlopen(req)
+                link=response.read()
+                response.close()
+
+                # Find videomega reference
+                match=re.compile("'text/javascript'>ref='(.+?)?';width.*iframe").findall(link)
+                if (len(match) == 1):
+                    return ['videomega.tv', match[0]]
+            except urllib2.URLError, e:
+                common.addon.log_error('Videomega: got http error %d fetching %s' %
+                                    (e.code, web_url))
+                return self.unresolvable(code=3, msg=e)
+            except Exception, e:
+                common.addon.log_error('**** Videomega Error occured: %s' % e)
+                common.addon.show_small_popup(title='[B][COLOR white]Videomega[/COLOR][/B]', msg='[COLOR red]%s[/COLOR]' % e, delay=5000, image=error_logo)
+        return False
 
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False

--- a/lib/urlresolver/plugins/videoraj.py
+++ b/lib/urlresolver/plugins/videoraj.py
@@ -33,6 +33,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VideorajResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videoraj.ch"
+    domains = [ "videoraj.ec", "videoraj.eu", "videoraj.sx", "videoraj.ch", "videoraj.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videotanker.py
+++ b/lib/urlresolver/plugins/videotanker.py
@@ -31,6 +31,7 @@ logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VideoTankerResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = 'videotanker'
+    domains = [ 'videotanker.co' ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videovalley.py
+++ b/lib/urlresolver/plugins/videovalley.py
@@ -27,6 +27,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videovalley.net"
+    domains = [ "videovalley.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videoweed.py
+++ b/lib/urlresolver/plugins/videoweed.py
@@ -32,6 +32,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VideoweedResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videoweed.es"
+    domains = [ "videoweed.es" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/videozed.py
+++ b/lib/urlresolver/plugins/videozed.py
@@ -29,6 +29,7 @@ net = Net()
 class VideozedResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "videozed"
+    domains = [ "videozed.net" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/vidplay.py
+++ b/lib/urlresolver/plugins/vidplay.py
@@ -30,6 +30,7 @@ net = Net()
 class VidplayResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidplay"
+    domains = [ "vidplay.net" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidspot.py
+++ b/lib/urlresolver/plugins/vidspot.py
@@ -26,6 +26,7 @@ from urlresolver import common
 class VidSpotResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidspot"
+    domains = [ "vidspot.net" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidstream.py
+++ b/lib/urlresolver/plugins/vidstream.py
@@ -30,6 +30,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VidstreamResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidstream"
+    domains = [ "vidstream.in" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidto.py
+++ b/lib/urlresolver/plugins/vidto.py
@@ -30,6 +30,7 @@ USER_AGENT='Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:30.0) Gecko/20100101 Firefo
 class vidto(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidto"
+    domains = [ "vidto.me" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidup_org.py
+++ b/lib/urlresolver/plugins/vidup_org.py
@@ -30,6 +30,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidup.org"
+    domains = [ "vidup.org" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidxden.py
+++ b/lib/urlresolver/plugins/vidxden.py
@@ -42,6 +42,7 @@ logo='http://googlechromesupportnow.com/wp-content/uploads/2012/06/Installation-
 class VidxdenResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidxden"
+    domains = [ 'vidxden.com', 'divxden.com', 'vidbux.com' ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vidzi.py
+++ b/lib/urlresolver/plugins/vidzi.py
@@ -31,6 +31,7 @@ USER_AGENT='Mozilla/5.0 (X11; Ubuntu; Linux i686; rv:30.0) Gecko/20100101 Firefo
 class SharesixResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidzi"
+    domains = [ "vidzi.tv" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/vidzur.py
+++ b/lib/urlresolver/plugins/vidzur.py
@@ -27,6 +27,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vidzur.com"
+    domains = [ "vidzur.com" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vimeo.py
+++ b/lib/urlresolver/plugins/vimeo.py
@@ -27,6 +27,7 @@ from urlresolver.plugnplay import Plugin
 class VimeoResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "vimeo"
+    domains = [ "vimeo.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vk.py
+++ b/lib/urlresolver/plugins/vk.py
@@ -36,6 +36,7 @@ ok_logo = os.path.join(common.addon_path, 'resources', 'images', 'greeninch.png'
 class VKResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "VK.com"
+    domains = [ "vk.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/vodlocker.py
+++ b/lib/urlresolver/plugins/vodlocker.py
@@ -31,7 +31,8 @@ logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class VodlockerResolver(Plugin, UrlResolver, PluginSettings):
     implements=[UrlResolver,PluginSettings]
     name="vodlocker.com"
-
+    domains=[ "vodlocker.com" ]
+    
     def __init__(self):
         p=self.get_setting('priority') or 100
         self.priority=int(p)

--- a/lib/urlresolver/plugins/watchfreeinhd.py
+++ b/lib/urlresolver/plugins/watchfreeinhd.py
@@ -29,6 +29,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class watchfreeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "watchfreeinhd"
+    domains = [ "watchfreeinhd.com" ]
 
 
     def __init__(self):

--- a/lib/urlresolver/plugins/xvidstage.py
+++ b/lib/urlresolver/plugins/xvidstage.py
@@ -27,6 +27,7 @@ from lib import jsunpack
 class XvidstageResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "xvidstage"
+    domains = [ "xvidstage.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/yourupload.py
+++ b/lib/urlresolver/plugins/yourupload.py
@@ -28,6 +28,7 @@ import re
 class FilenukeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "yourupload.com"
+    domains = [ "yourupload.com" ]
     
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugins/youtube.py
+++ b/lib/urlresolver/plugins/youtube.py
@@ -27,6 +27,7 @@ from urlresolver.plugnplay import Plugin
 class YoutubeResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "youtube"
+    domains = [ 'youtube.com', 'youtu.be' ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100
@@ -57,10 +58,9 @@ class YoutubeResolver(Plugin, UrlResolver, PluginSettings):
             common.addon.log_error('youtube: video id not found')
             return self.unresolvable(code=0, msg="youtube: video id not found")
 
-
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False
-        return re.match('http://(((www.)?youtube.+?(v|embed)(=|/))|' +
+        return re.match('http[s]*://(((www.|m.)?youtube.+?(v|embed)(=|/))|' +
                         'youtu.be/)[0-9A-Za-z_\-]+', 
                         url) or 'youtube' in host or 'youtu.be' in host
 

--- a/lib/urlresolver/plugins/youwatch.py
+++ b/lib/urlresolver/plugins/youwatch.py
@@ -67,6 +67,7 @@ class Base36:
 class YouwatchResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
     implements = [UrlResolver, SiteAuth, PluginSettings]
     name = "youwatch"
+    domains = [ "youwatch.org" ]
     profile_path = common.profile_path    
     cookie_file  = os.path.join(profile_path, '%s.cookies' % name)
 

--- a/lib/urlresolver/plugins/zalaa.py
+++ b/lib/urlresolver/plugins/zalaa.py
@@ -31,6 +31,7 @@ error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
 class ZalaaResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "zalaa"
+    domains = [ "zalaa.com" ]
 
     def __init__(self):
         p = self.get_setting('priority') or 100

--- a/lib/urlresolver/plugnplay/interfaces.py
+++ b/lib/urlresolver/plugnplay/interfaces.py
@@ -81,7 +81,10 @@ class UrlResolver(Interface):
     # Don't support any internet domain
     domains = ['localdomain']
     
-    '''(array) List of domains handled by this plugin. Use ["*"] for universal resolvers.'''
+    '''(array) List of domains handled by this plugin.
+          (!) Write in a single line.
+          (!) Use ["*"] for universal resolvers.
+    '''
     
     class unresolvable():
         '''
@@ -356,8 +359,10 @@ class UrlWrapper(UrlResolver, PluginSettings, SiteAuth, AutoloadPlugin):
     _ref = UrlStub()
     implements = []
     _re_implements = re.compile('\s+implements\s*=\s*\[(.*)\]')
+    _re_domains = re.compile('\s+domains\s*=\s*\[(.*)\]')
     _re_name = re.compile('\s+name\s*=\s*[\'"](.*)[\'"]')
     _found_implements = False
+    _found_domains = False
     _found_name = False
 
     def __init__(self):
@@ -369,6 +374,12 @@ class UrlWrapper(UrlResolver, PluginSettings, SiteAuth, AutoloadPlugin):
             Find the lines that define which domains are supported,
             and which interface is implemented.
         '''
+        if not self._found_domains:
+            res = self._re_domains.match(line)
+            if res:
+                self._ref.domains = res.group(1).translate(None,' "\'').split(',')
+                self._found_domains = True
+
         if not self._found_implements:
             res = self._re_implements.match(line)
             if res:
@@ -376,16 +387,16 @@ class UrlWrapper(UrlResolver, PluginSettings, SiteAuth, AutoloadPlugin):
                 for handler in implements_names:
                     self.implements.append(globals()[handler])
                 self._found_implements = True
-        
+
         if not self._found_name:
             res = self._re_name.match(line)
             if res:
                 self.name = res.group(1)
                 self._found_name = True
-    
+
     def plugin_ready(self):
-        return (self._found_implements and self._found_name)
-    
+        return (self._found_domains and self._found_implements and self._found_name)
+
     @classmethod
     def implementors(klass):
         return UrlResolver.implementors()

--- a/lib/urlresolver/types.py
+++ b/lib/urlresolver/types.py
@@ -16,10 +16,11 @@
 
 import urlresolver
 import urllib2
-import urlparse
+from urlparse import urlparse
 from urlresolver import common
 from plugnplay.interfaces import UrlResolver
 from plugnplay.interfaces import SiteAuth
+import re, sys
 
 class HostedMediaFile:
     '''
@@ -72,26 +73,41 @@ class HostedMediaFile:
         self._url = url
         self._host = host
         self._media_id = media_id
-        
-        self._resolvers = self._find_resolvers()
-        if url and self._resolvers and self._resolvers[0].get_host_and_id(url):
-            self._host, self._media_id = self._resolvers[0].get_host_and_id(url)
-        elif self._resolvers:
-            if self._resolvers[0].isUniversal():
-                if len(self._resolvers) > 1:
-                    self._url = self._resolvers[1].get_url(host, media_id)
-                    result = self._resolvers[0].get_host_and_id(self._url)
-                    if result:
-                        self._host, self._media_id = result
-                    else:
-                        self._resolvers = []
-            else:    
-                self._url = self._resolvers[0].get_url(host, media_id)
+        self._valid_url = None
+
+        if (self._url):
+            self._domain = self.__top_domain(self._url)
+        else:
+            self._domain = self.__top_domain(self._host)
+            self._url = self._media_id
+
+        self.__resolvers = self.__find_resolvers(
+            common.addon.get_setting('allow_universal') == "true")
+
+        if url == '':
+            for resolver in self.__resolvers:  # Find a valid URL
+                try:
+                    if resolver.get_url(host, media_id):
+                        self._url = resolver.get_url(host, media_id)
+                        break
+                except:
+                    # Shity resolver. Ignore
+                    continue
+
         if title:
             self.title = title
         else:
             self.title = self._host
-            
+
+    def __top_domain(self, url):
+        regex = "(\w{2,}\.\w{2,3}\.\w{2}|\w{2,}\.\w{2,3})$"
+        elements = urlparse(url)
+        domain = elements.netloc or elements.path
+        domain = domain.split('@')[-1].split(':')[0]
+        res = re.search(regex, domain)
+        if res:
+            return res.group(1)
+        return domain
 
     def get_url(self):
         '''
@@ -131,21 +147,23 @@ class HostedMediaFile:
             A direct URL to the media file that is playable by XBMC, or False
             if this was not possible. 
         '''
-        if self._resolvers:
-            # universal resolvers aren't resolvable without a url
-            if len(self._resolvers)==1 and self._resolvers[0].isUniversal() and not self._url:
-                return False
-            
-            resolver = self._resolvers[0]
-            common.addon.log_debug('resolving using %s plugin' % resolver.name)
-            if SiteAuth in resolver.implements:
-                common.addon.log_debug('logging in')
-                resolver.login()
-
-            stream_url = resolver.get_media_url(self._host, self._media_id)
-            if stream_url and self.__test_stream(stream_url):
-                    return stream_url
-
+        for resolver in self.__resolvers:
+            try:
+                common.addon.log_debug('resolving using %s plugin' % resolver.name)
+                if resolver.valid_url(self._url, self._host):
+                    if SiteAuth in resolver.implements:
+                        common.addon.log_debug('logging in')
+                        resolver.login()
+                    self._host, self._media_id = resolver.get_host_and_id(self._url)
+                    stream_url = resolver.get_media_url(self._host, self._media_id)
+                    if stream_url and self.__test_stream(stream_url):
+                        self.__resolvers = [ resolver ] # Found a valid resolver, ignore the others
+                        self._valid_url = True
+                        return stream_url
+            except:
+                common.addon.log_notice("Resolver '%s' crashed. Ignore" % resolver.name)
+                continue
+        self.__resolvers = [] # No resolvers.
         return False
         
     def valid_url(self):
@@ -163,8 +181,17 @@ class HostedMediaFile:
                     print 'resolvable!'
             
         '''
-        if self._resolvers:
-            return True
+        if None != self._valid_url: return self._valid_url
+        for resolver in self.__resolvers:
+            try:
+                if resolver.valid_url(self._url, self._domain):
+                    self._valid_url = True
+                    return True
+            except:
+                # print sys.exc_info()
+                continue
+        self._valid_url = False
+        self.__resolvers = []
         return False
         
     def __test_stream(self, stream_url):
@@ -197,17 +224,20 @@ class HostedMediaFile:
         
         return int(http_code) < 400
     
-    def _find_resolvers(self):
+    def __find_resolvers(self, universal=False):
         urlresolver.lazy_plugin_scan()
-        imps = []
-        for imp in UrlResolver.implementors():
-            if imp.valid_url(self.get_url(), self.get_host()):
-                imps.append(imp)
-        return imps
+        resolvers = []
+        for resolver in UrlResolver.implementors():
+            if (self._domain in resolver.domains):
+                resolvers.append(resolver)
+            elif (universal and ('*' in resolver.domains)):
+                resolvers.append(resolver)
+        return resolvers
 
         
     def __nonzero__(self):
-        return self.valid_url() 
+        if None == self._valid_url: return self.valid_url()
+        return self._valid_url
         
     def __str__(self):
         return '{\'url\': \'%s\', \'host\': \'%s\', \'media_id\': \'%s\'}' % (


### PR DESCRIPTION
Here comes the controversial change: add domain-check before evaluating URL's.

## Background
Using valid_url() method provides urlresolver plugins with flexibility to decide if a given URL can be resolved or not. But it also introduces a performance penalty due to the need to load all resolvers into memory and the need to compile and execute hundreds of regex.

Most valid_url() implementations look something like this (from clody.py):

```python
class CloudyResolver(Plugin, UrlResolver, PluginSettings):
    implements = [UrlResolver, PluginSettings]
    name = "cloudy.ec"
# [...] 
    def valid_url(self, url, host):
        if self.get_setting('enabled') == 'false': return False
        return re.match('https?://(?:www\.|embed\.)cloudy\.(?:ec|eu|sx|ch|com)/(?:video/|embed\.php\?id=)([0-9a-z]+)', url) or 'cloudy.' in host
```

It's obvious that the information used to match a URL is static and could be optimized some way. Only universal resolvers use a truly dynamic url validation.

## Solution

The solution in this patch, is adding a static list of supported hosts that can be parsed (*coarse*) before calling 'valid_url()' (*fine*)

The re-written version of previous snippet would be:

```python
class CloudyResolver(Plugin, UrlResolver, PluginSettings):
    implements = [UrlResolver, PluginSettings]
    name = "cloudy.ec"
    domains = [ "cloudy.ec", "cloudy.eu", "cloudy.sx", "cloudy.ch", "cloudy.com" ]
```

It requires interpreting all the existing regex "by hand" to create the list, but doesn't require modifying any code in the plugin. 

The rest of the solution is:

1. Parse the domain list while listing the plugins (`interfaces.py`).
2. Create a first list of possible resolvers before calling valid_url() (`types.py`)
3. For universal resolvers, we added a wildcard `['*']`
