### PR TITLE
settings.xml fixes/improvements

### DIFF
--- a/lib/urlresolver/plugins/180upload.py
+++ b/lib/urlresolver/plugins/180upload.py
@@ -53,7 +53,6 @@ class OneeightyuploadResolver(Plugin, UrlResolver, PluginSettings):
             # Check for file not found
             if re.search('File Not Found', html):
                 common.addon.log_error(self.name + ' - File Not Found')
-                xbmc.executebuiltin('XBMC.Notification([B][COLOR white]180Upload[/COLOR][/B],[COLOR red]File has been deleted[/COLOR],8000,'+error_logo+')')
                 return self.unresolvable(code=1, msg='File Not Found') 
                 
             data = {}
@@ -116,11 +115,9 @@ class OneeightyuploadResolver(Plugin, UrlResolver, PluginSettings):
         except urllib2.URLError, e:
             common.addon.log_error(self.name + ': got http error %d fetching %s' %
                                    (e.code, web_url))
-            common.addon.show_small_popup('Error','Http error: '+str(e), 5000, error_logo)
             return self.unresolvable(code=3, msg=e)
         except Exception, e:
             common.addon.log_error('**** 180upload Error occured: %s' % e)
-            common.addon.show_small_popup(title='[B][COLOR white]180UPLOAD[/COLOR][/B]', msg='[COLOR red]%s[/COLOR]' % e, delay=5000, image=error_logo)
             return self.unresolvable(code=0, msg=e)
 
         

--- a/lib/urlresolver/plugins/divxstage.py
+++ b/lib/urlresolver/plugins/divxstage.py
@@ -24,9 +24,6 @@ import re, urllib2, os
 from urlresolver import common
 from lib import unwise
 
-#SET ERROR_LOGO# THANKS TO VOINAGE, BSTRDMKR, ELDORADO
-error_logo = os.path.join(common.addon_path, 'resources', 'images', 'redx.png')
-
 class DivxstageResolver(Plugin, UrlResolver, PluginSettings):
     implements = [UrlResolver, PluginSettings]
     name = "divxstage"
@@ -48,7 +45,7 @@ class DivxstageResolver(Plugin, UrlResolver, PluginSettings):
                 html = unwise.unwise_process(html)
                 filekey = unwise.resolve_var(html, "flashvars.filekey")
                 
-                player_url = 'http://www.divxstage.eu/api/player.api.php?user=undefined&key='+filekey+'&pass=undefined&codes=1&file='+media_id
+                player_url = 'http://www.cloudtime.to/api/player.api.php?user=undefined&key='+filekey+'&pass=undefined&codes=1&file='+media_id
                 html = self.net.http_GET(player_url).content
                 r = re.search('url=(.+?)&', html)
                 if r:
@@ -60,11 +57,9 @@ class DivxstageResolver(Plugin, UrlResolver, PluginSettings):
         except urllib2.URLError, e:
             common.addon.log_error(self.name + ': got http error %d fetching %s' %
                                    (e.code, web_url))
-            common.addon.show_small_popup('Error','Http error: '+str(e), 5000, error_logo)
             return self.unresolvable(code=3, msg=e)
         except Exception, e:
             common.addon.log_error('**** Divxstage Error occured: %s' % e)
-            common.addon.show_small_popup(title='[B][COLOR white]DIVXSTAGE[/COLOR][/B]', msg='[COLOR red]%s[/COLOR]' % e, delay=5000, image=error_logo)
             return self.unresolvable(code=0, msg=e)
 
     def get_url(self, host, media_id):
@@ -83,4 +78,4 @@ class DivxstageResolver(Plugin, UrlResolver, PluginSettings):
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False
         #http://embed.divxstage.eu/embed.php?v=8da26363e05fd&width=746&height=388&c=000
-        return (re.match('http://(?:www.|embed.)?divxstage.(?:eu|net|to)/', url) or 'divxstage' in host)
+        return (re.match('http://(?:www.|embed.)?(?:divxstage\.(?:eu|net|to)|cloudtime\.to)/', url) or 'divxstage' in host)

--- a/lib/urlresolver/plugins/movshare.py
+++ b/lib/urlresolver/plugins/movshare.py
@@ -46,10 +46,12 @@ class MovshareResolver(Plugin, UrlResolver, PluginSettings):
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
+        print web_url
         """ Human Verification """
         try:
             self.net.http_HEAD(web_url)
             html = self.net.http_GET(web_url).content
+            print html
             """movshare can do both flv and avi. There is no way I know before hand
             if the url going to be a flv or avi. So the first regex tries to find 
             the avi file, if nothing is present, it will check for the flv file.
@@ -84,7 +86,7 @@ class MovshareResolver(Plugin, UrlResolver, PluginSettings):
         return 'http://www.movshare.net/video/%s' % media_id
 
     def get_host_and_id(self, url):
-        r = re.search('//(.+?)/(?:video|embed)/([0-9a-z]+)', url)
+        r = re.search('//(.+?)/(?:video/|embed\.php\?v=)([0-9a-z]+)', url)
         if r:
             return r.groups()
         else:
@@ -92,5 +94,6 @@ class MovshareResolver(Plugin, UrlResolver, PluginSettings):
 
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False
-        return re.match('http://(?:www.)?movshare.net/(?:video|embed)/',
+        print url
+        return re.match('http://(?:www|embed)\.?movshare.net/(?:video|embed)',
                         url) or 'movshare' in host

--- a/lib/urlresolver/plugins/movshare.py
+++ b/lib/urlresolver/plugins/movshare.py
@@ -46,12 +46,10 @@ class MovshareResolver(Plugin, UrlResolver, PluginSettings):
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
-        print web_url
         """ Human Verification """
         try:
             self.net.http_HEAD(web_url)
             html = self.net.http_GET(web_url).content
-            print html
             """movshare can do both flv and avi. There is no way I know before hand
             if the url going to be a flv or avi. So the first regex tries to find 
             the avi file, if nothing is present, it will check for the flv file.
@@ -94,6 +92,5 @@ class MovshareResolver(Plugin, UrlResolver, PluginSettings):
 
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False
-        print url
         return re.match('http://(?:www|embed)\.?movshare.net/(?:video|embed)',
                         url) or 'movshare' in host

--- a/lib/urlresolver/plugins/uploadc.py
+++ b/lib/urlresolver/plugins/uploadc.py
@@ -45,34 +45,31 @@ class UploadcResolver(Plugin, UrlResolver, PluginSettings):
         try:
             html = self.net.http_GET(web_url).content
 
-            #send all form values
-            sPattern = '<input.*?name="([^"]+)".*?value=([^>]+)>'
-            r = re.findall(sPattern, html)
             data = {}
+            r = re.findall(r'type="hidden" name="(.+?)" value="(.+?)"', html)
             if r:
-                for match in r:
-                    name = match[0]
-                    value = match[1].replace('"','')
+                for name, value in r:
                     data[name] = value
-
-                html = self.net.http_POST(web_url, data).content
+                data['referer'] = web_url 
             else:
-                raise Exception ('File Not Found or removed')
+                raise Exception('Cannot find data values')
+
+            html = self.net.http_POST(web_url, data).content
             
-            # modified by mscreations. get the file url from the returned javascript
-            match = re.search("addVariable[(]'file','(.+?)'[)]", html, re.DOTALL + re.IGNORECASE)
-            if match:
-                return match.group(1)+'|Referer=http%3A%2F%2Fwww.uploadc.com%2Fplayer%2Fplayer-embed.swf'
-        
+            for match in re.finditer('(eval\(function.*?)</script>', html, re.DOTALL):
+                js_data =  jsunpack.unpack(match.group(1))
+                r = re.search('src="([^"]+)', js_data)
+                if r:
+                    stream_url = r.group(1) + '|referer=' + web_url
+                    return stream_url
+                    
             raise Exception ('File Not Found or removed')
         except urllib2.URLError, e:
             common.addon.log_error(self.name + ': got http error %d fetching %s' %
                                    (e.code, web_url))
-            common.addon.show_small_popup('Error','Http error: '+str(e), 8000, error_logo)
             return self.unresolvable(code=3, msg=e)
         except Exception, e:
             common.addon.log('**** Uploadc Error occured: %s' % e)
-            common.addon.show_small_popup(title='[B][COLOR white]UPLOADC[/COLOR][/B]', msg='[COLOR red]%s[/COLOR]' % e, delay=5000, image=error_logo)
             return self.unresolvable(code=0, msg=e)
 
     def get_url(self, host, media_id):
@@ -84,7 +81,6 @@ class UploadcResolver(Plugin, UrlResolver, PluginSettings):
             return r.groups()
         else:
             return False
-
 
     def valid_url(self, url, host):
         if self.get_setting('enabled') == 'false': return False

--- a/lib/urlresolver/types.py
+++ b/lib/urlresolver/types.py
@@ -160,6 +160,8 @@ class HostedMediaFile:
                     if stream_url:
                         # if we got a valid url back, then test it and only return the valid stream_url if the test succeeds
                         if self.__test_stream(stream_url):
+                            self.__resolvers = [ resolver ] # Found a valid resolver, ignore the others
+                            self._valid_url = True
                             return stream_url
                         else:
                             return False
@@ -187,7 +189,7 @@ class HostedMediaFile:
                     print 'resolvable!'
             
         '''
-        if None != self._valid_url: return self._valid_url
+        if self._valid_url is not None: return self._valid_url
         for resolver in self.__resolvers:
             try:
                 if resolver.valid_url(self._url, self._domain):
@@ -242,7 +244,7 @@ class HostedMediaFile:
 
         
     def __nonzero__(self):
-        if None == self._valid_url: return self.valid_url()
+        if self._valid_url is None: return self.valid_url()
         return self._valid_url
         
     def __str__(self):

--- a/lib/urlresolver/types.py
+++ b/lib/urlresolver/types.py
@@ -156,9 +156,15 @@ class HostedMediaFile:
                         resolver.login()
                     self._host, self._media_id = resolver.get_host_and_id(self._url)
                     stream_url = resolver.get_media_url(self._host, self._media_id)
-                    if stream_url and self.__test_stream(stream_url):
-                        self.__resolvers = [ resolver ] # Found a valid resolver, ignore the others
-                        self._valid_url = True
+                    # this logic is weird because get_media_url returns an object of class unresolvable that evals to False when resolve fails
+                    if stream_url:
+                        # if we got a valid url back, then test it and only return the valid stream_url if the test succeeds
+                        if self.__test_stream(stream_url):
+                            return stream_url
+                        else:
+                            return False
+                    # return the unresolvable if there's not a True stream_url
+                    else:
                         return stream_url
             except:
                 common.addon.log_notice("Resolver '%s' crashed. Ignore" % resolver.name)


### PR DESCRIPTION
This fixes resolver sorting and groups resolvers into categories to avoid >100 xbmc errors.

I break the category each time the number of settings in the category exceeds MAX_SETTINGS. I currently set that to 75. XBMC's limit is 100. That gives some room just in case one resolver has lots of settings.