### PR TITLE
Fix cloudy.ec resolver

### DIFF
--- a/lib/urlresolver/plugins/cloudy.py
+++ b/lib/urlresolver/plugins/cloudy.py
@@ -80,7 +80,7 @@ class CloudyResolver(Plugin, UrlResolver, PluginSettings):
         #grab stream details
         html = self.net.http_GET(web_url).content
         html = unwise.unwise_process(html)
-        filekey = unwise.resolve_var(html, "flashvars.filekey")
+        filekey = unwise.resolve_var(html, "vars.key")
 
         error_url = None
         stream_url = None

--- a/lib/urlresolver/plugins/lib/unwise.py
+++ b/lib/urlresolver/plugins/lib/unwise.py
@@ -124,7 +124,7 @@ def resolve_var(HTML, key): #this should probably be located elsewhere
         else:
             key = key.split("\\.")
             if len(key) == 2:
-                tmp2 = re.compile(r'[^\w\.]' + key[0] + '\s*=\s*\{.*' + key[1] + '\s*:\s*[\"\'](.*?)[\"\']').search(tmp1) #for 'vars = { key: "value" }', cloudy
+                tmp2 = re.compile(r'[^\w\.]' + key[0] + '\s*=\s*\{.*[^\w\.]' + key[1] + '\s*:\s*[\"\'](.*?)[\"\']').search(tmp1) #for 'vars = { key: "value" }', cloudy
             if tmp2:
                 tmp2 = tmp2.group(1)
             else:

--- a/lib/urlresolver/plugins/lib/unwise.py
+++ b/lib/urlresolver/plugins/lib/unwise.py
@@ -122,7 +122,13 @@ def resolve_var(HTML, key): #this should probably be located elsewhere
         if tmp2:
             tmp2 = tmp2.group(1)
         else:
-            tmp2 = "" #oops, should not happen in the variable is valid
+            key = key.split("\\.")
+            if len(key) == 2:
+                tmp2 = re.compile(r'[^\w\.]' + key[0] + '\s*=\s*\{.*' + key[1] + '\s*:\s*[\"\'](.*?)[\"\']').search(tmp1) #for 'vars = { key: "value" }', cloudy
+            if tmp2:
+                tmp2 = tmp2.group(1)
+            else:
+                tmp2 = "" #oops, should not happen in the variable is valid
     return tmp2
 
 if __name__ == "__main__":

--- a/lib/urlresolver/plugins/lib/unwise.py
+++ b/lib/urlresolver/plugins/lib/unwise.py
@@ -124,7 +124,7 @@ def resolve_var(HTML, key): #this should probably be located elsewhere
         else:
             key = key.split("\\.")
             if len(key) == 2:
-                tmp2 = re.compile(r'[^\w\.]' + key[0] + '\s*=\s*\{.*[^\w\.]' + key[1] + '\s*:\s*[\"\'](.*?)[\"\']').search(tmp1) #for 'vars = { key: "value" }', cloudy
+                tmp2 = re.compile(r'[^\w\.]' + key[0] + '\s*=\s*\{.*[^\w\.]' + key[1] + '\s*\:\s*[\"\'](.*?)[\"\']').search(tmp1) #for 'vars = { key: "value" }', cloudy
             if tmp2:
                 tmp2 = tmp2.group(1)
             else:


### PR DESCRIPTION
It was failing to detect the filekey, it seems 'flashvars.filekey' was renamed.

This changes 'flashvars.filekey' to 'vars.key' and allows resolve_var to handle objects defined like:

    var vars = {
        cid:"1", 
        numOfErrors: "0", 
        cid2: "", 
        cid3:"", 
        user:"", 
        pass:"", 
        domain: "http://www.cloudy.ec",
        key: "XXXXXXXXXXXXXX",
        file:"XXXXXXXXXXXXX", 
        crk:"1",      
        skin : "/play/skins/gblue.xml",
    };