### PR TITLE
Fixing local variable error in real-debrid plugin

### DIFF
--- a/lib/urlresolver/plugins/realdebrid.py
+++ b/lib/urlresolver/plugins/realdebrid.py
@@ -100,7 +100,9 @@ class RealDebridResolver(Plugin, UrlResolver, SiteAuth, PluginSettings):
                 label = '[%s] %s' % (link['quality'], link['download'])
             else:
                 label = link['download']
-        return (label, link['download'])
+            return (label, link['download'])
+        else:
+            return None
         
     # SiteAuth methods
     def login(self):


### PR DESCRIPTION
Label was referenced when it often didn't exist, causing an error. This resolves that error.