### PR TITLE
File Upload.af url

### DIFF
--- a/lib/urlresolver/plugins/uploadaf.py
+++ b/lib/urlresolver/plugins/uploadaf.py
@@ -51,4 +51,4 @@ class UploadAfResolver(UrlResolver):
         raise ResolverError('Unable to resolve upload.af link. Filelink not found.')
 
     def get_url(self, host, media_id):
-        return 'http://upload.af/%s' % (media_id)
+        return 'https://upload.af/%s' % (media_id)


### PR DESCRIPTION
When using _http://_ on upload.af urls, resolver fails with
```
Icefilms: Unable to play selected source.
Please try another.  Unable to resolve upload.af link. Filelink not found.
```

Using http**s**:// solves it.